### PR TITLE
Standardize gRPC port to 50051

### DIFF
--- a/charts/files/values.yaml
+++ b/charts/files/values.yaml
@@ -62,7 +62,7 @@ service:
       targetPort: http
       protocol: TCP
     - name: grpc
-      port: 9090
+      port: 50051
       targetPort: grpc
       protocol: TCP
 
@@ -71,7 +71,7 @@ containerPorts:
     containerPort: 8080
     protocol: TCP
   - name: grpc
-    containerPort: 9090
+    containerPort: 50051
     protocol: TCP
 
 command: []
@@ -165,7 +165,7 @@ metrics:
 
 files:
   httpAddress: ":8080"
-  grpcAddress: ":9090"
+  grpcAddress: ":50051"
   maxFileSize: 20971520
   databaseUrl:
     value: ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,7 +11,7 @@ import (
 
 const (
 	defaultHTTPAddress = ":8080"
-	defaultGRPCAddress = ":9090"
+	defaultGRPCAddress = ":50051"
 	defaultS3Region    = "us-east-1"
 )
 


### PR DESCRIPTION
## Summary
- update default gRPC address and chart ports to 50051

## Testing
- buf generate buf.build/agynio/api --template buf.gen.yaml --path agynio/api/files/v1/files.proto
- go test ./...

Refs #7