### PR TITLE
fix(chart): split service templates

### DIFF
--- a/charts/files/templates/deployment.yaml
+++ b/charts/files/templates/deployment.yaml
@@ -1,0 +1,2 @@
+{{- include "files.configureEnv" . -}}
+{{- include "service-base.deployment" . -}}

--- a/charts/files/templates/hpa.yaml
+++ b/charts/files/templates/hpa.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.hpa" . -}}

--- a/charts/files/templates/ingress.yaml
+++ b/charts/files/templates/ingress.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.ingress" . -}}

--- a/charts/files/templates/metrics.yaml
+++ b/charts/files/templates/metrics.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.metrics" . -}}

--- a/charts/files/templates/pdb.yaml
+++ b/charts/files/templates/pdb.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.pdb" . -}}

--- a/charts/files/templates/rbac.yaml
+++ b/charts/files/templates/rbac.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.rbac" . -}}

--- a/charts/files/templates/service-base.yaml
+++ b/charts/files/templates/service-base.yaml
@@ -1,9 +1,0 @@
-{{- include "files.configureEnv" . -}}
-{{- include "service-base.rbac" . -}}
-{{- include "service-base.serviceAccount" . -}}
-{{- include "service-base.service" . -}}
-{{- include "service-base.deployment" . -}}
-{{- include "service-base.hpa" . -}}
-{{- include "service-base.ingress" . -}}
-{{- include "service-base.pdb" . -}}
-{{- include "service-base.metrics" . -}}

--- a/charts/files/templates/service.yaml
+++ b/charts/files/templates/service.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.service" . -}}

--- a/charts/files/templates/serviceaccount.yaml
+++ b/charts/files/templates/serviceaccount.yaml
@@ -1,0 +1,1 @@
+{{- include "service-base.serviceAccount" . -}}


### PR DESCRIPTION
## Summary
- remove combined service-base template and restore per-resource templates
- ensure deployment template configures env before service-base deployment
- keep Helm chart layout aligned with service-base includes

## Testing
- buf generate buf.build/agynio/api --path agynio/api/files/v1
- go test ./...
- go vet ./...
- helm lint charts/files --set files.databaseUrl.value=postgres://user:pass@host/db --set files.s3.endpoint=http://s3 --set files.s3.bucket=bucket --set files.s3.accessKey.value=access --set files.s3.secretKey.value=secret

Refs: #27