### PR TITLE
Fix tenant_id nullable in migration

### DIFF
--- a/migrations/0002_add_tenant_id.sql
+++ b/migrations/0002_add_tenant_id.sql
@@ -1,5 +1,5 @@
 ALTER TABLE files
-    ADD COLUMN tenant_id UUID NOT NULL;
+    ADD COLUMN tenant_id UUID;
 
 DROP INDEX IF EXISTS idx_files_created_at;
 


### PR DESCRIPTION
## Summary
- allow nullable tenant_id in migration 0002

## Testing
- buf generate buf.build/agynio/api --path agynio/api/files/v1
- go build ./...
- go test ./...
- go vet ./...

Fixes #29