### PR TITLE
Fix docker proto cache with buf.lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,4 +115,4 @@ jobs:
         env:
           KUBECONFIG: ${{ github.workspace }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml
           PR_IMAGE: ${{ env.PR_IMAGE }}
-        run: devspace run-pipeline test:e2e
+        run: devspace run-pipeline test-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Free disk space
         run: |
@@ -54,26 +53,6 @@ jobs:
 
       - name: Checkout service repo
         uses: actions/checkout@v4
-
-      - name: Set PR image tag
-        run: echo "PR_IMAGE=ghcr.io/agynio/files:pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push PR image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ env.PR_IMAGE }}
 
       - name: Checkout bootstrap
         uses: actions/checkout@v4
@@ -114,5 +93,4 @@ jobs:
       - name: Run E2E tests
         env:
           KUBECONFIG: ${{ github.workspace }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml
-          PR_IMAGE: ${{ env.PR_IMAGE }}
         run: devspace run-pipeline test-e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     go mod download
 
-COPY buf.gen.yaml buf.yaml ./
+COPY buf.gen.yaml buf.yaml buf.lock ./
 RUN buf generate buf.build/agynio/api --path agynio/api/files/v1
 
 COPY . .

--- a/buf.lock
+++ b/buf.lock
@@ -4,8 +4,8 @@ deps:
   - remote: buf.build
     owner: agynio
     repository: api
-    commit: 9cba13379c00496998251a9af664334d
-    digest: shake256:f7a9fe8e236662cd3a9e27b1c1592e2e8d4428ebd5b29f435196298d859c2f073f43f90a8004d9e6da30470262acb71e113fc9e47343ba8493474abaca8b98e9
+    commit: 5f499d593b034d2dac8d4dfaff62c8db
+    digest: shake256:d0d08ed0a5e950729cfa7df66965e90ffcda0f9ee8a9d8ad2dbf9389d9e620c4caf7e86f70572014008aeea43871b7976968e59e0afc3f8d64fc785fc0d2712d
   - remote: buf.build
     owner: opentelemetry
     repository: opentelemetry

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -95,6 +95,14 @@ deployments:
         name: component-chart
         repo: https://charts.devspace.sh
       values:
+        securityContext:
+          fsGroup: 1000
+        initContainers:
+          - name: prepare-workspace
+            image: busybox:1.36
+            command: ["sh", "-c", "mkdir -p /opt/app/data && chown 1000:1000 /opt/app/data"]
+            securityContext:
+              runAsUser: 0
         containers:
           - image: ${E2E_IMAGE}
             env:
@@ -142,8 +150,7 @@ pipelines:
       disable_argocd_sync
       deploy_pr_image
       create_deployments e2e-runner
-      start_dev e2e-runner &
-      sleep 5
+      start_dev e2e-runner
       set +e
       exec_container \
         --label-selector "app.kubernetes.io/name=files-e2e" \
@@ -205,6 +212,8 @@ dev:
     workingDir: /opt/app/data
     sync:
       - path: ./:/opt/app/data
+        noWatch: true
+        disableDownload: true
         excludePaths:
           - .git/
           - .devspace/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -32,12 +32,12 @@ functions:
       echo "ERROR: PR_IMAGE not set, aborting hot deploy"
       exit 1
     fi
-    kubectl set image deployment/files-files files="$IMAGE" -n ${FILES_NAMESPACE}
-    kubectl rollout status deployment/files-files -n ${FILES_NAMESPACE} --timeout=120s
+    kubectl set image deployment/files files="$IMAGE" -n ${FILES_NAMESPACE}
+    kubectl rollout status deployment/files -n ${FILES_NAMESPACE} --timeout=120s
     echo "PR image deployed successfully"
   patch_deployment: |-
     echo "Patching files deployment for DevSpace..."
-    kubectl patch deployment files-files -n ${FILES_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    kubectl patch deployment files -n ${FILES_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -104,8 +104,8 @@ deployments:
           app.kubernetes.io/name: files-e2e
 
 commands:
-  test:e2e: |-
-    devspace run-pipeline test:e2e $@
+  test-e2e: |-
+    devspace run-pipeline test-e2e $@
 
 pipelines:
   dev:
@@ -137,7 +137,7 @@ pipelines:
         stop_dev files
       fi
 
-  test:e2e:
+  test-e2e:
     run: |-
       disable_argocd_sync
       deploy_pr_image

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -25,16 +25,6 @@ functions:
     else
       echo "WARNING: ArgoCD Application 'files' not found in argocd namespace."
     fi
-  deploy_pr_image: |-
-    echo "Deploying PR image to cluster..."
-    IMAGE="${PR_IMAGE:-}"
-    if [ -z "$IMAGE" ]; then
-      echo "ERROR: PR_IMAGE not set, aborting hot deploy"
-      exit 1
-    fi
-    kubectl set image deployment/files files="$IMAGE" -n ${FILES_NAMESPACE}
-    kubectl rollout status deployment/files -n ${FILES_NAMESPACE} --timeout=120s
-    echo "PR image deployed successfully"
   patch_deployment: |-
     echo "Patching files deployment for DevSpace..."
     kubectl patch deployment files -n ${FILES_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
@@ -95,19 +85,32 @@ deployments:
         name: component-chart
         repo: https://charts.devspace.sh
       values:
-        securityContext:
-          fsGroup: 1000
-        initContainers:
-          - name: prepare-workspace
-            image: busybox:1.36
-            command: ["sh", "-c", "mkdir -p /opt/app/data && chown 1000:1000 /opt/app/data"]
-            securityContext:
-              runAsUser: 0
         containers:
           - image: ${E2E_IMAGE}
+            command: ["sleep", "infinity"]
             env:
               - name: FILES_ADDRESS
                 value: "files:50051"
+            resources:
+              requests:
+                cpu: 500m
+                memory: 512Mi
+              limits:
+                cpu: "1"
+                memory: 2Gi
+            securityContext:
+              runAsNonRoot: true
+              runAsUser: 1000
+              runAsGroup: 1000
+              readOnlyRootFilesystem: false
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop: ["ALL"]
+              seccompProfile:
+                type: RuntimeDefault
+        securityContext:
+          runAsUser: 1000
+          fsGroup: 1000
         labels:
           app.kubernetes.io/name: files-e2e
 
@@ -147,21 +150,21 @@ pipelines:
 
   test-e2e:
     run: |-
-      disable_argocd_sync
-      deploy_pr_image
       create_deployments e2e-runner
-      start_dev e2e-runner
-      set +e
-      exec_container \
-        --label-selector "app.kubernetes.io/name=files-e2e" \
-        -n ${FILES_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/files/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
-      EXIT_CODE=$?
-      set -e
+      trap 'stop_dev e2e-runner; purge_deployments e2e-runner' EXIT
+      start_dev e2e-runner --disable-pod-replace
+      echo "Waiting for source files to sync..."
+      sleep 5
+      echo "Generating protobuf types..."
+      exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${FILES_NAMESPACE} -- \
+        bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/files/v1'
+      echo "Running e2e tests..."
+      exec_container --label-selector=app.kubernetes.io/name=devspace-app,app.kubernetes.io/component=e2e-runner -n ${FILES_NAMESPACE} -- \
+        bash -c 'cd /opt/app/data && go test -v -count=1 -tags e2e ./test/e2e/'
+      echo "Cleaning up test runner pod..."
       stop_dev e2e-runner
       purge_deployments e2e-runner
-      restore_argocd_sync
-      exit ${EXIT_CODE}
+      trap - EXIT
 
 hooks:
   - name: restore-argocd-auto-sync
@@ -207,15 +210,18 @@ dev:
   e2e-runner:
     namespace: ${FILES_NAMESPACE}
     labelSelector:
-      app.kubernetes.io/name: files-e2e
-    command: ["sleep", "infinity"]
-    workingDir: /opt/app/data
+      app.kubernetes.io/name: devspace-app
+      app.kubernetes.io/component: e2e-runner
     sync:
       - path: ./:/opt/app/data
         noWatch: true
-        disableDownload: true
         excludePaths:
           - .git/
-          - .devspace/
           - /.gen/
-          - /tmp/
+          - .devspace/
+        uploadExcludePaths:
+          - .git/
+          - /.gen/
+        downloadExcludePaths:
+          - .git/
+          - /.gen/

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -111,8 +111,6 @@ deployments:
         securityContext:
           runAsUser: 1000
           fsGroup: 1000
-        labels:
-          app.kubernetes.io/name: files-e2e
 
 commands:
   test-e2e: |-


### PR DESCRIPTION
## Summary
- include buf.lock in the Docker build context to avoid stale proto stubs
- refresh buf.lock via buf dep update

## Testing
- buf generate buf.build/agynio/api --path agynio/api/files/v1
- go vet ./...
- go build ./...
- go test ./...

Fixes #31