### PR TITLE
fix(ci): align e2e pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
     timeout-minutes: 60
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Free disk space
         run: |
@@ -54,26 +53,6 @@ jobs:
 
       - name: Checkout service repo
         uses: actions/checkout@v4
-
-      - name: Set PR image tag
-        run: echo "PR_IMAGE=ghcr.io/agynio/files:pr-${{ github.event.pull_request.number || github.run_id }}-${{ github.sha }}" >> $GITHUB_ENV
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build and push PR image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: ${{ env.PR_IMAGE }}
 
       - name: Checkout bootstrap
         uses: actions/checkout@v4
@@ -114,5 +93,8 @@ jobs:
       - name: Run E2E tests
         env:
           KUBECONFIG: ${{ github.workspace }}/bootstrap/stacks/k8s/.kube/agyn-local-kubeconfig.yaml
-          PR_IMAGE: ${{ env.PR_IMAGE }}
-        run: devspace run-pipeline test:e2e
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            devspace dev
+          fi
+          devspace run test-e2e

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ devspace dev -w
 ### Run tests
 
 ```bash
-devspace run test:e2e
+devspace run test-e2e
 ```
 
 See [E2E Testing](https://github.com/agynio/architecture/blob/main/architecture/operations/e2e-testing.md).

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -54,6 +54,16 @@ functions:
                   done
                   buf generate buf.build/agynio/api --path agynio/api/files/v1
                   exec go run ./cmd/files
+              livenessProbe:
+                exec:
+                  command: ["true"]
+                initialDelaySeconds: 0
+                periodSeconds: 10
+              readinessProbe:
+                exec:
+                  command: ["true"]
+                initialDelaySeconds: 0
+                periodSeconds: 5
               volumeMounts:
                 - name: data
                   mountPath: /opt/app/data

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -25,16 +25,6 @@ functions:
     else
       echo "WARNING: ArgoCD Application 'files' not found in argocd namespace."
     fi
-  deploy_pr_image: |-
-    echo "Deploying PR image to cluster..."
-    IMAGE="${PR_IMAGE:-}"
-    if [ -z "$IMAGE" ]; then
-      echo "ERROR: PR_IMAGE not set, aborting hot deploy"
-      exit 1
-    fi
-    kubectl set image deployment/files-files files="$IMAGE" -n ${FILES_NAMESPACE}
-    kubectl rollout status deployment/files-files -n ${FILES_NAMESPACE} --timeout=120s
-    echo "PR image deployed successfully"
   patch_deployment: |-
     echo "Patching files deployment for DevSpace..."
     kubectl patch deployment files-files -n ${FILES_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
@@ -104,8 +94,8 @@ deployments:
           app.kubernetes.io/name: files-e2e
 
 commands:
-  test:e2e: |-
-    devspace run-pipeline test:e2e $@
+  test-e2e: |-
+    devspace run-pipeline test-e2e $@
 
 pipelines:
   dev:
@@ -137,24 +127,19 @@ pipelines:
         stop_dev files
       fi
 
-  test:e2e:
+  test-e2e:
     run: |-
-      disable_argocd_sync
-      deploy_pr_image
       create_deployments e2e-runner
       start_dev e2e-runner &
       sleep 5
-      set +e
       exec_container \
         --label-selector "app.kubernetes.io/name=files-e2e" \
         -n ${FILES_NAMESPACE} \
         -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/files/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
-      set -e
       stop_dev e2e-runner
       purge_deployments e2e-runner
-      restore_argocd_sync
-      exit ${EXIT_CODE}
+      exit $EXIT_CODE
 
 hooks:
   - name: restore-argocd-auto-sync

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -27,7 +27,7 @@ functions:
     fi
   patch_deployment: |-
     echo "Patching files deployment for DevSpace..."
-    kubectl patch deployment files-files -n ${FILES_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    kubectl patch deployment files -n ${FILES_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -27,6 +27,7 @@ functions:
     fi
   patch_deployment: |-
     echo "Patching files deployment for DevSpace..."
+    kubectl patch deployment files -n ${FILES_NAMESPACE} --type json -p '[{"op":"remove","path":"/spec/template/spec/containers/0/livenessProbe"},{"op":"remove","path":"/spec/template/spec/containers/0/readinessProbe"}]'
     kubectl patch deployment files -n ${FILES_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
@@ -54,16 +55,6 @@ functions:
                   done
                   buf generate buf.build/agynio/api --path agynio/api/files/v1
                   exec go run ./cmd/files
-              livenessProbe:
-                exec:
-                  command: ["true"]
-                initialDelaySeconds: 0
-                periodSeconds: 10
-              readinessProbe:
-                exec:
-                  command: ["true"]
-                initialDelaySeconds: 0
-                periodSeconds: 5
               volumeMounts:
                 - name: data
                   mountPath: /opt/app/data


### PR DESCRIPTION
## Summary
- rename the DevSpace test pipeline/command and remove service deployment logic from test-e2e
- simplify the e2e CI job to run devspace dev for PRs before test-e2e
- update the README e2e command

## Testing
- buf generate buf.build/agynio/api --path agynio/api/files/v1
- go vet ./...
- go build ./...
- go test ./...

#33