### PR TITLE
fix(chart): allow environment S3 wiring

### DIFF
--- a/charts/files/templates/_helpers.tpl
+++ b/charts/files/templates/_helpers.tpl
@@ -17,10 +17,10 @@
 {{- end }}
 {{- $env = append $env $dbVar -}}
 
-{{- $endpoint := required "files.s3.endpoint is required" (trimAll " \n\t" (default "" .Values.files.s3.endpoint)) -}}
+{{- $endpoint := trimAll " \n\t" (default "" .Values.files.s3.endpoint) -}}
 {{- $env = append $env (dict "name" "S3_ENDPOINT" "value" $endpoint) -}}
 
-{{- $bucket := required "files.s3.bucket is required" (trimAll " \n\t" (default "" .Values.files.s3.bucket)) -}}
+{{- $bucket := trimAll " \n\t" (default "" .Values.files.s3.bucket) -}}
 {{- $env = append $env (dict "name" "S3_BUCKET" "value" $bucket) -}}
 
 {{- $region := trimAll " \n\t" (default "us-east-1" .Values.files.s3.region) -}}


### PR DESCRIPTION
## Summary
- Allows the files chart to render with empty S3 endpoint/bucket defaults so environment wiring can provide them.
- Keeps S3 credentials on the default agyn-files-s3 Secret keys.

Refs agynio/platform-charts#4

## Validation
- `helm dependency build charts/files`
- `helm lint charts/files`
- `helm template test charts/files`

Results: 1 chart linted, 0 failed; template render succeeded.