### PR TITLE
fix(chart): set numeric files user

### DIFF
--- a/charts/files/values.yaml
+++ b/charts/files/values.yaml
@@ -40,6 +40,8 @@ podSecurityContext:
 securityContext:
   enabled: true
   runAsNonRoot: true
+  runAsUser: 100
+  runAsGroup: 101
   readOnlyRootFilesystem: true
   allowPrivilegeEscalation: false
   capabilities:


### PR DESCRIPTION
## Summary
- Set default container `securityContext.runAsUser` to `100`.
- Set default container `securityContext.runAsGroup` to `101`.
- Keeps the fix in the files chart defaults only; no umbrella/provisioning workaround.

Closes #46

## Validation
- `CGO_ENABLED=0 go test ./...`
- `CGO_ENABLED=0 go vet ./...`
- `helm dependency build charts/files`
- `helm lint charts/files --set files.databaseUrl.value=postgres://user:pass@host/db --set files.s3.endpoint=minio:9000 --set files.s3.bucket=files --set files.s3.accessKey.value=test --set files.s3.secretKey.value=test`
- `helm template files charts/files --set files.databaseUrl.value=postgres://user:pass@host/db --set files.s3.endpoint=minio:9000 --set files.s3.bucket=files --set files.s3.accessKey.value=test --set files.s3.secretKey.value=test >/tmp/files-rendered.yaml`
- Render verification: files container securityContext includes `runAsNonRoot: true`, `runAsUser: 100`, and `runAsGroup: 101`.

## Release note
Per release guard policy, chart release should happen only after this PR merges.