### PR TITLE
ci(e2e): provision the platform VM instead of bootstrap

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@main
+        uses: agynio/e2e/.github/actions/provision-vm@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main
@@ -50,20 +50,16 @@ jobs:
           node <<'NODE'
           const fs = require('fs');
 
+          // This job checks e2e out itself and patches the suites below, so the
+          // action must not check it out again on top of them. Matched by step
+          // name rather than by its exact text: pinning the whole block meant
+          // any edit to the action -- an added input, a changed ref expression
+          // -- broke this job instead of the action.
           const actionPath = 'e2e/.github/actions/run-tests/action.yml';
-          const checkoutStep = [
-            '    - name: Checkout e2e repository',
-            '      uses: actions/checkout@v4',
-            '      with:',
-            '        repository: agynio/e2e',
-            '        ref: main',
-            '        path: e2e',
-            '',
-            '',
-          ].join('\n');
           let action = fs.readFileSync(actionPath, 'utf8');
-          if (!action.includes(checkoutStep)) {
-            throw new Error('expected checkout step not found in e2e run-tests action');
+          const checkoutStep = /^ {4}- name: Checkout e2e repository\n(?: {5,}.*\n|\n)*?(?=^ {4}- name: )/m;
+          if (!checkoutStep.test(action)) {
+            throw new Error('expected a "Checkout e2e repository" step in the e2e run-tests action');
           }
           action = action.replace(checkoutStep, '');
           fs.writeFileSync(actionPath, action);

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -130,7 +130,6 @@ dev:
     namespace: ${FILES_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: files
-      app.kubernetes.io/instance: files
     containers:
       files:
         container: files


### PR DESCRIPTION
Swaps cluster provisioning from `agynio/bootstrap/.github/actions/provision` to `agynio/e2e/.github/actions/provision-vm`, which boots the prebuilt platform VM and exports the same environment `run-tests` already reads.

Part of retiring `agynio/bootstrap`.